### PR TITLE
Post-process dual matrix for SDPOPF and SparseSDPOPF

### DIFF
--- a/src/opf/sdpwrm.jl
+++ b/src/opf/sdpwrm.jl
@@ -237,12 +237,13 @@ function extract_dual(opf::OPFModel{SDPOPF})
 
     if has_duals(model)
         S = dual.(model[:S])  # 2N * 2N, with four N * N blocks
+        S = (S + S') / 2  # ensure symmetry
 
         # Bus-level constraints
         dual_solution["kcl_p"] = dual.(model[:kcl_p])
         dual_solution["kcl_q"] = dual.(model[:kcl_q])
-        # diagonal of the upper-left block of S
-        dual_solution["s"] = [S[i, i] for i in 1:N]
+        # Diagonal mean of S[1,1] and S[2,2] blocks
+        dual_solution["s"] = [(S[i, i] + S[i + N, i + N]) / 2 for i in 1:N]
 
         # Generator-level constraints
         # N/A
@@ -259,9 +260,11 @@ function extract_dual(opf::OPFModel{SDPOPF})
         # that don't are 0.
         # If there are multiple branches from bus i to j, the same entries of S are extracted for
         # each of the branches.
-        dual_solution["sr"] = [S[bus_fr[e], bus_to[e]] for e in 1:E] # upper left block of S
-        dual_solution["si"] = [S[bus_fr[e], bus_to[e] + N] for e in 1:E] # upper right block of S
-        
+        # Mean of S[1,1] and S[2,2] blocks
+        dual_solution["sr"] = [(S[bus_fr[e], bus_to[e]] + S[bus_fr[e] + N, bus_to[e] + N]) / 2 for e in 1:E]
+        # Mean of upper triangle and lower triangle of S[1,2] block
+        dual_solution["si"] = [(S[bus_fr[e], bus_to[e] + N] - S[bus_to[e], bus_fr[e] + N]) / 2 for e in 1:E]
+
         # For conic constraints, JuMP will return Vector{Vector{T}}
         # reshape duals of conic constraints into matrix shape
         dual_solution["sm_fr"] = mapreduce(permutedims, vcat, dual_solution["sm_fr"])

--- a/src/opf/sparse_sdpwrm.jl
+++ b/src/opf/sparse_sdpwrm.jl
@@ -314,10 +314,12 @@ function extract_dual(opf::OPFModel{SparseSDPOPF})
         for (gidx, group) in enumerate(groups)
             n = length(group)
             S_g = dual.(constraint_by_name(model, "S_$(gidx)"))  # 2n * 2n, with four n * n blocks
+            S_g = (S_g + S_g') / 2  # ensure symmetry
             WR_g = model[Symbol("WR_$(gidx)")]
             for i in 1:n
                 i_bus = group[i]
-                dual_solution["s"][i_bus] += S_g[i, i]
+                # Diagonal mean of S_g[1,1] and S_g[2,2] blocks
+                dual_solution["s"][i_bus] += (S_g[i, i] + S_g[i + n, i + n]) / 2
                 # For mu_w, we also need to sum the values multiple times for the same bus, since bounds
                 # have been imposed on all linked w variables
                 dual_solution["w"][i_bus] += dual(LowerBoundRef(WR_g[i, i])) + dual(UpperBoundRef(WR_g[i, i]))
@@ -330,10 +332,12 @@ function extract_dual(opf::OPFModel{SparseSDPOPF})
                 i_bus, j_bus = group[i], group[j]
                 # If there are multiple branches from bus i to j, the same entries of S are extracted for
                 # each of the branches.
-                e_idx = findall(==((i_bus, j_bus)), zip(bus_fr, bus_to) |> collect)
+                e_idx = findall(i -> bus_fr[i] == i_bus && bus_to[i] == j_bus, 1:E)
                 for e in e_idx
-                    dual_solution["sr"][e] += S_g[i, j]
-                    dual_solution["si"][e] += S_g[i, j + n]
+                    # Mean of S_g[1,1] and S_g[2,2] blocks
+                    dual_solution["sr"][e] += (S_g[i, j] + S_g[i + n, j + n]) / 2
+                    # Mean of upper triangle and lower triangle of S_g[1,2] block
+                    dual_solution["si"][e] += (S_g[i, j + n] - S_g[j, i + n]) / 2
                 end
             end
         end

--- a/src/opf/sparse_sdpwrm.jl
+++ b/src/opf/sparse_sdpwrm.jl
@@ -71,20 +71,23 @@ function build_opf(::Type{SparseSDPOPF}, data::OPFData, optimizer;
             # note that bounds are added for all the linked variables and not just one of them
             set_lower_bound.(WR_g[i, i], vmin[i_bus]^2)
             set_upper_bound.(WR_g[i, i], vmax[i_bus]^2)
-            # match each bus to one of the WR_g's
+            # if i_bus is currently unmatched, link it to WR_g[i, i]
             if !(i_bus in visited_buses)
                 push!(visited_buses, i_bus)
                 w_map[i_bus] = WR_g[i, i]
             end
         end
 
-        # Match each branch to one of the entries of WR_g and of WI_g
-        # Iterate over both directions of each bus pair since a branch may exist in either direction
+        # Match the entries of WR_g and of WI_g to branches
+        # Iterate over both directions of each bus pair in `group` since a branch may exist in either direction
         offdiag_indices = [(i, j) for i in 1:n, j in 1:n if i != j]
         for (i, j) in offdiag_indices
             i_bus, j_bus = group[i], group[j]
             # if there exists a branch from i_bus to j_bus
             if (i_bus, j_bus) in zip(bus_fr, bus_to)
+                # If the bus pair is currently unmatched, link it to WR_g[i, j] and WI_g[i, j]
+                # Note that even if there are multiple branches, the same directed bus pair is
+                # only matched once
                 if !((i_bus, j_bus) in visited_directed_buspairs)
                     push!(visited_directed_buspairs, (i_bus, j_bus))
                     wr_map[(i_bus, j_bus)] = WR_g[i, j]

--- a/test/opf/sdpwrm.jl
+++ b/test/opf/sdpwrm.jl
@@ -60,7 +60,7 @@ end
 
 Test dual feasibility of SDPWRM problem.
 
-This test is executed on the 5 bus system.
+This test is executed on the 5-bus system to save time for CI. It is recommended to run this test on larger systems locally.
 """
 function _test_sdpwrm_DualFeasibility(OPF::Union{Type{PGLearn.SDPOPF}, Type{PGLearn.SparseSDPOPF}})
     T = Float128
@@ -95,7 +95,7 @@ Tests feasibility for dual constraints associated to `WR` and `WI` variables.
 
 # Arguments
 - `data::OPFData`: OPF instance data
-- `res`: Result dictionary of the SOCWR optimization
+- `res`: Result dictionary of the SDPWRM optimization
 - `atol=1e-6`: The absolute tolerance for feasibility checks (default is 1e-6).
 """
 function _test_sdpwrm_DualFeasibility(data::PGLearn.OPFData, res; atol=1e-6)

--- a/test/opf/sdpwrm.jl
+++ b/test/opf/sdpwrm.jl
@@ -129,14 +129,15 @@ function _test_sdpwrm_DualFeasibility(data::PGLearn.OPFData, res; atol=1e-6)
     
     # Reconstruct S from s, sr, si
     S = Symmetric(sparse(
-        vcat([1:N;], [N+1 : 2*N;], bus_fr, bus_to, bus_fr .+ N, bus_to .+ N, bus_fr, bus_to),
-        vcat([1:N;], [N+1 : 2*N;], bus_to, bus_fr, bus_to .+ N, bus_fr .+ N, bus_to .+ N, bus_fr .+ N),
+        vcat(1:N, N+1 : 2*N, bus_fr, bus_to, bus_fr .+ N, bus_to .+ N, bus_fr, bus_to),
+        vcat(1:N, N+1 : 2*N, bus_to, bus_fr, bus_to .+ N, bus_fr .+ N, bus_to .+ N, bus_fr .+ N),
         # Symmetric() uses the upper triangular part of the matrix, but there may be branches where f_bus > t_bus (entry is below the diagonal), so we repeat sr for both directions of each branch
         vcat(s, s, sr, sr, sr, sr, si, -si),
         2*N, 2*N,
         # ignore duplicate values at the same position
         (x, y) -> x
     ))
+    @test eigmin(Matrix(S)) >= -atol
 
     # Check dual constraint corresponding to `WR` variables
     AR_ff_values = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,8 @@ const OPT_SOLVERS = Dict(
 
 
 const PGLIB_CASES = ["14_ieee", "30_ieee", "57_ieee", "89_pegase", "118_ieee"]
+# Only include the 14-bus case for SDP tests to save time for CI.
+# It is recommended to run SDP tests on larger systems locally, preferably with commercial solvers or Clarabel with Float128.
 const PGLIB_CASES_SDP = ["14_ieee"]
 @testset "PGLearn" begin
     include("utils/io.jl")


### PR DESCRIPTION
The dual to the primal PSD matrix
```math
\begin{pmatrix} WR & WI \\ -WI & WR \end{pmatrix}
```
is supposed to have the same block structure where the [1,1] block is equal to the [2,2] block and the [1,2] block and [2,1] block sum to 0.

In some cases, they can in fact differ a lot in the numerical solutions. Because we only extract certain entries of the dual matrix, a post-processing (taking the average of the entries that are supposed to be equal) is necessary to ensure reconstruction of a feasible matrix.